### PR TITLE
Upgrade dependencies, edit README, fix borked mixin name

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,10 @@ Guides that revolve around Minecraft-specific java code and systems will not wor
 2. Open the project in your IDE and let Gradle initialise itself.
    Due to the nature of Loom and the game's size, this may take a few minutes.
    If you have your game installed to a different location than Steam's default path,
-   make sure you set the path in your `build.gradle` file like so:
+   make sure you set the following environment variable (depending on your OS this is done in different ways):
 
-   ```gradle
-   loom {
-       loom_client_install_path = 'D:\\SteamLibrary\\steamapps\\common\\ProjectZomboid'
-   }
+   ```
+   LEAF_CLIENT_GAME_PATH = D:\SteamLibrary\steamapps\common\ProjectZomboid
    ```
 
    If you are on a bad SSD, this may be 5-10 minutes, or on a HDD this could be 25+ minutes.

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "dev.aoqia.leaf.loom" version "${loom_version}"
+    alias(libs.plugins.leaf.loom)
     id "maven-publish"
 }
 
@@ -28,9 +28,9 @@ loom {
 
 dependencies {
     // To change the versions see the gradle.properties file
-    zomboid "com.theindiestone:zomboid:${project.zomboid_version}"
-    mappings "dev.aoqia.leaf:yarn:${project.yarn_mappings}:v2"
-    modImplementation "dev.aoqia.leaf:loader:${project.loader_version}"
+    zomboid libs.zomboid
+    mappings variantOf(libs.leaf.yarn) { classifier("v2") }
+    modImplementation libs.leaf.loader
 
     // Leaf API. This is technically optional, but you probably want it anyway.
     // Commented out as Leaf API has yet to exist, this is a placeholder.

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'dev.aoqia.leaf.loom' version '0.3.0'
-    id 'maven-publish'
+    id "dev.aoqia.leaf.loom" version "${loom_version}"
+    id "maven-publish"
 }
 
 base {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@ org.gradle.parallel=true
 zomboid_version=41.78.16
 yarn_mappings=41.78.16+build.1
 loader_version=1.1.0
+loom_version=0.5.1
 
 # Mod Properties
 version=1.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,12 +2,6 @@
 org.gradle.jvmargs=-Xmx4096m
 org.gradle.parallel=true
 
-# Leaf Properties
-zomboid_version=41.78.16
-yarn_mappings=41.78.16+build.1
-loader_version=1.1.0
-loom_version=0.5.1
-
 # Mod Properties
 version=1.0.0
 group=com.example

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,7 @@
+[libraries]
+zomboid = { group = "com.theindiestone", name = "zomboid", version = "41.78.16" }
+leaf-yarn = { group = "dev.aoqia.leaf", name = "yarn", version = "41.78.16+build.1" }
+leaf-loader = { group = "dev.aoqia.leaf", name = "loader", version = "1.1.0" }
+
+[plugins]
+leaf-loom = { id = "dev.aoqia.leaf.loom", version = "0.5.1" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/example/ExampleMod.java
+++ b/src/main/java/com/example/ExampleMod.java
@@ -16,7 +16,7 @@ public class ExampleMod implements ModInitializer {
     public void onInitialize() {
         LOGGER.debugln("[%s] %s", MOD_ID, "Hello Leaf World!!! >w<");
 
-        // Registers the events. Actually called in ExampleVersionMixin.
+        // Registers the events. Actually called in ExampleMixin.
         LuaEventManager.AddEvent(GAME_VERSION_CHANGED_EVENT);
     }
 }

--- a/src/main/java/com/example/mixin/ExampleMixin.java
+++ b/src/main/java/com/example/mixin/ExampleMixin.java
@@ -12,7 +12,7 @@ import static com.example.ExampleMod.GAME_VERSION_CHANGED_EVENT;
 import static com.example.ExampleMod.LOGGER;
 
 @Mixin(Core.class)
-public class CoreMixin {
+public class ExampleMixin {
     @Inject(method = "getVersion", at = @At("RETURN"), cancellable = true)
     private void getVersion(CallbackInfoReturnable<String> cir) {
         LOGGER.println("Changing the internal game version.");


### PR DESCRIPTION
- Updated `gradle` to `8.14.2` and `leaf-loom` to `0.5.1`
- Added gradle property `loom_version`, as it was the only version that wasn't controlled through a property, now everything is in a single place
- Renamed `CoreMixin` to `ExampleMixin`, `ExampleMixin` was already being referenced in `modid.mixins.json` so this makes it so it works.
- Updated the custom game install path guide