### PR TITLE
Fix typo in processResources task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ tasks {
         filesMatching("leaf.mod.json") {
             expand(
                 "version" to inputs.properties["version"],
-                "loader_version" to inputs.properties["loader_verison"],
+                "loader_version" to inputs.properties["loader_version"],
                 "zomboid_version" to inputs.properties["zomboid_version"]
             )
         }


### PR DESCRIPTION
- Fixed typo that led to `"leafloader": ">=null"` in `leaf.mod.json` dependency list